### PR TITLE
Fix breakage caused by systemd service library reorganization

### DIFF
--- a/src/lib/hanafirewallui/main_dialog.rb
+++ b/src/lib/hanafirewallui/main_dialog.rb
@@ -19,7 +19,12 @@
 require 'yast'
 require 'ui/dialog'
 require 'hanafirewall/hanafirewall_conf'
-require 'yast2/systemd_unit'
+
+begin
+  require 'yast2/systemd/unit'
+rescue LoadError
+  require 'yast2/systemd_unit'
+end
 
 Yast.import 'UI'
 Yast.import 'Icon'


### PR DESCRIPTION
In https://github.com/yast/yast-yast2/commit/e4ab10035ba30f739175009344872c4062c26db6, the layout of the systemd related library was changed. This commit, which was originally written as a fix for bsc#1146220 makes yast2-hana-firewall to work with this reorganization (but includes backwards compatible alternative so it should work in both cases).